### PR TITLE
use $this->app->make instead of resolve

### DIFF
--- a/src/ElasticsearchProvider.php
+++ b/src/ElasticsearchProvider.php
@@ -12,7 +12,7 @@ class ElasticsearchProvider extends ServiceProvider
      */
     public function boot()
     {
-        resolve(EngineManager::class)->extend('elasticsearch', function ($app) {
+        $this->app->make(EngineManager::class)->extend('elasticsearch', function ($app) {
             return new ElasticsearchEngine(ElasticBuilder::create()
                     ->setHosts(config('scout.elasticsearch.config.hosts'))
                     ->build(),


### PR DESCRIPTION
Somehow resolve() helper started returning string on Laravel 5.3.29.
use `$this->app->make` instead of `resolver()`